### PR TITLE
Changed btcd Github URL

### DIFF
--- a/includes/mainblock.html
+++ b/includes/mainblock.html
@@ -2,7 +2,7 @@
 	<p>
 		This site is written in <a href="http://www.golang.org">Go</a>.
 		It uses JSON to fetch and parse this data from
-		<a href="https://github.com/conformal/btcd">btcd</a> on-demand.
+		<a href="https://github.com/btcsuite/btcd">btcd</a> on-demand.
 	</p>
 </section>
 <section class="row">


### PR DESCRIPTION
It still pointed to conformal/btcd instead of btcsuite/btcd
